### PR TITLE
Update main.py for PES

### DIFF
--- a/gvasp/main.py
+++ b/gvasp/main.py
@@ -407,7 +407,7 @@ def main(argv=None):
                     logger.warning(f"style argument is not exist in {args.json}, use default value")
 
                 if 'legends' not in arguments:
-                    arguments['legends'] = [None, None, None]
+                    arguments['legends'] = [None] * len(arguments['data'])
                     logger.warning(f"legends argument is not exist in {args.json}, use default value")
 
                 if color_lack:


### PR DESCRIPTION
The issue of the number of lines in drawing potential energy surfaces is no more than 3 (old main.py)

Try this: 

function:  gvasp plot PES -j plot.json --show

plot.json:
{"color":["#FF0000","#FF8C00","#FFD700","#FF00FF"],
"data":[[0,0.82,-1.58,0.42,-2.08],
		[0,0.33,-1.66,null,-3.27],
		[0,0.50,1.00,0.40,0.30],
		[0,1.0,0.30,0.40,-0.80]],
"text_flag": false
}

for old main.py it looks like:
<img width="1112" alt="image" src="https://github.com/Rasic2/gvasp/assets/62542718/3548f10c-9c04-483f-9a25-cb59f02af45e">

for new main.py it should be like:
<img width="1115" alt="image" src="https://github.com/Rasic2/gvasp/assets/62542718/16833e5e-961e-44f5-aa28-5644a5c32d6c">
