### PR TITLE
做能带图时遇见的问题的解决方法

### DIFF
--- a/gvasp/common/base.py
+++ b/gvasp/common/base.py
@@ -127,7 +127,7 @@ class Lattice(object):
         Returns:
             lattice (Lattice): Lattice instance
         """
-        matrix = np.array([[float(ii) for ii in item.split()[:3]] for item in string])
+        matrix = np.array([[float(num) for num in re.findall(r'[+-]?\d+\.?\d*(?:[eE][+-]?\d+)?', line)[:3]] for line in string])
         return Lattice(matrix)
 
     @staticmethod

--- a/gvasp/common/file.py
+++ b/gvasp/common/file.py
@@ -1414,7 +1414,7 @@ class OUTCAR(MetaFile):
         self.spin = [int(line.split()[2]) for line in self.strings if "ISPIN" in line][0]
         self.bands, self.kpoints = \
             [(int(line.split()[-1]), int(line.split()[3])) for line in self.strings if
-             "NBANDS" in line and "the" not in line][0]
+             "NBANDS=" in line and "the" not in line][0]
         steps = [(index, int(line.split()[2].split("(")[0]), int(line.split()[3].split(")")[0]))
                  for index, line in enumerate(self.strings) if "Iteration" in line]
         self.steps = namedtuple("Steps", ("index", "ionic", "electronic"))(*list(map(tuple, zip(*steps))))


### PR DESCRIPTION
gvasp/common/file.py    1417行 改动 由于INCAR中手动设置了NBANDS，但是与实际的NBANDS有出入，这是计算的OUTCAR会多几行关于NBANDS的输出（如图），使得找不到正确的NBABDS值，当加了=即可解决。
<img width="1629" height="240" alt="image" src="https://github.com/user-attachments/assets/b81db132-c83d-4dc1-a65b-113a0875e007" />

common/base.py  131行 如果POSCAR中晶格位数太长且有负号，在如图OUTCAR中提取晶格常数的时候会出错，当用正则表达式提取的时候即可解决。
<img width="1263" height="152" alt="image" src="https://github.com/user-attachments/assets/cd97d025-ce41-48f2-8f7d-bc5329e7bc44" />
